### PR TITLE
Depend on ppx_deriving_yojson and lambda-term

### DIFF
--- a/opam
+++ b/opam
@@ -20,11 +20,11 @@ depends: [
   "menhir"
   ("extlib"|"extlib-compat")
   "lwt" {>= "2.4.6"}
-  "ppx_deriving" {>= "1.0"}
+  "ppx_deriving_yojson" {>= "2.0"}
   "ppx_tools" {build & >= "0.99.1"}
   "oasis" {build & >= "0.4"}
   "cppo" {build}
   "containers"
+  "lambda-term" {build}
 ]
-depopts: ["lambda-term" {build}]
 available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
It seems this is necessary for OPAM to build the `rmp` binary.